### PR TITLE
Add a custom __setattr__ to set update attributes inside of _values if

### DIFF
--- a/src/terraformpy/objects.py
+++ b/src/terraformpy/objects.py
@@ -93,6 +93,12 @@ class NamedObject(TFObject):
         self._values = _values or {}
         self._values.update(kwargs)
 
+    def __setattr__(self, name, value):
+        if '_values' in self.__dict__ and name in self.__dict__['_values']:
+            self.__dict__['_values'][name] = value
+        else:
+            self.__dict__[name] = value
+
     def __getattr__(self, name):
         """This is here as a safety so that you cannot generate hard to debug .tf.json files"""
         if not TFObject._frozen and name in self._values:

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -76,6 +76,17 @@ def test_getattr():
         assert var1.id, 'nope!  vars do not have attrs!'
 
 
+def test_setattr():
+    res1 = Resource('res1', 'foo', attr='value')
+
+    assert res1.attr == "value"
+    assert res1._values['attr'] == "value"
+
+    res1.not_tf_attr = "value"
+    assert res1.not_tf_attr == "value"
+    assert 'not_tf_attr' not in res1._values
+
+
 def test_tf_type():
     TFObject.reset()
 


### PR DESCRIPTION
they exist, otherwise set object level attribute

Now that we have updated `__getattr__` to fetch the value from `self._values` if the object isn't frozen and it exists in `self._values`, we need to provide a custom `__setattr__` function that will update `self._values` when the attribute is assigned, if it already exists in `self._values`

Ran into some fun with infinite recursion implementing this. Not sure if this is the most elegant way to accomplish it, but it works.