### PR TITLE
Add Variant support to NamedObjects

### DIFF
--- a/src/terraformpy/objects.py
+++ b/src/terraformpy/objects.py
@@ -6,7 +6,7 @@ while also leveraging Python to add some functional aspects to automate some of 
 import collections
 import six
 
-from .resource_collections import ResourceCollection
+from .resource_collections import ResourceCollection, Variant
 
 
 def recursive_update(dest, source):
@@ -91,7 +91,15 @@ class NamedObject(TFObject):
         """
         self._name = _name
         self._values = _values or {}
-        self._values.update(kwargs)
+
+        if Variant.CURRENT_VARIANT is None:
+            self._values.update(kwargs)
+        else:
+            for name in kwargs:
+                if not name.endswith('_variant'):
+                    self._values[name] = kwargs[name]
+                elif name == '{0}_variant'.format(Variant.CURRENT_VARIANT.name):
+                    self._values.update(kwargs[name])
 
     def __setattr__(self, name, value):
         if '_values' in self.__dict__ and name in self.__dict__['_values']:

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -1,6 +1,6 @@
 import pytest
 
-from terraformpy import TFObject, Data, Resource, Variable
+from terraformpy import TFObject, Data, Resource, Variable, Variant
 
 
 def test_object_instances():
@@ -115,3 +115,14 @@ def test_access_before_compile():
     TFObject._frozen = True
 
     assert sg.ingress == '${aws_security_group.sg.ingress}'
+
+
+def test_object_variants():
+    with Variant('foo'):
+        sg = Resource(
+            'aws_security_group', 'sg',
+            foo_variant=dict(ingress=['foo']),
+            bar_variant=dict(ingress=['bar'])
+        )
+
+        assert sg.ingress == ['foo']


### PR DESCRIPTION
To support things like different bucket names within IAM policies we need to add variant support for our object hierarchy.

When constructing NamedObjects (or any of it's descendants) we now check if we have a variant.  If we don't we just pull in all the kwargs to our values.  If we do then we move over anything from kwargs that doesn't end in `_variant`, and only pull in values from our current named variant -- if it exists.