### PR TITLE
Support duplicate Provider names

### DIFF
--- a/src/terraformpy/__init__.py
+++ b/src/terraformpy/__init__.py
@@ -1,5 +1,5 @@
 from .resource_collections import ResourceCollection, Input, Variant  # noqa
-from .objects import TFObject, Provider, Variable, Data, Resource, Output  # noqa 
+from .objects import TFObject, Provider, Variable, Data, Resource, Output, DuplicateKey  # noqa 
 
 # add a couple shortcuts
 compile = TFObject.compile

--- a/src/terraformpy/objects.py
+++ b/src/terraformpy/objects.py
@@ -20,6 +20,12 @@ def recursive_update(dest, source):
     return dest
 
 
+# Provider names are duplicate keys in the resulting json, so we need a way to represent that
+class DuplicateKey(str):
+    def __hash__(self):
+        return id(self)
+
+
 class TFObject(object):
     _instances = None
     _frozen = False
@@ -170,6 +176,15 @@ class TypedObject(NamedObject):
 class Provider(NamedObject):
     """Represents a Terraform provider configuration"""
     TF_TYPE = "provider"
+
+    # override build to support duplicate key values
+    def build(self):
+        result = {
+            self.TF_TYPE: {
+                DuplicateKey(self._name): self._values
+            }
+        }
+        return result
 
 
 class Variable(NamedObject):

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -1,6 +1,7 @@
 import pytest
 
-from terraformpy import TFObject, Data, Resource, Variable, Variant
+import json
+from terraformpy import TFObject, Data, Resource, Variable, Variant, DuplicateKey, Provider
 
 
 def test_object_instances():
@@ -126,3 +127,23 @@ def test_object_variants():
         )
 
         assert sg.ingress == ['foo']
+
+
+def test_duplicate_key():
+    x = {DuplicateKey("mysql"): {"user": "wyatt"}, DuplicateKey("mysql"): {"user": "wyatt"}}
+    encoded = json.dumps(x, sort_keys=True)
+    desired = '{"mysql": {"user": "wyatt"}, "mysql": {"user": "wyatt"}}'
+    assert encoded == desired
+
+
+# Make sure provider supports duplicate key names
+def test_provider():
+    TFObject.reset()
+
+    Provider("mysql", host="db-wordpress")
+    Provider("mysql", host="db-finpro")
+
+    result = json.dumps(TFObject.compile(), sort_keys=True)
+    desired = '{"provider": {"mysql": {"host": "db-wordpress"}, "mysql": {"host": "db-finpro"}}}'
+
+    assert result == desired


### PR DESCRIPTION
Terraform's configuration syntax for Providers allows you to define multiple providers of the same type. This means that the final provider object can contain multiple objects with the same key name, for example multiple "mysql" keys. Because we are representing state as Python dictionaries, we can not have the same key name multiple times.

To solve this, we've introduced a DuplicateKey object that can be used as a key, and will hash to a string when encoded, allowing a final JSON output result with identical names.

Hashicorp's decision to use duplicate key names within an object is questionable. However, The JavaScript Object Notation (JSON) Data Interchange Format) (RFC7159) says:

The names within an object SHOULD be unique.

In this context, SHOULD is a highly recommended practice, but not a requirement.

Further reference:

https://www.terraform.io/docs/configuration/providers.html
http://stackoverflow.com/questions/21832701/does-json-syntax-allow-duplicate-keys-in-an-object

https://tools.ietf.org/html/rfc7159#section-4
http://www.ietf.org/rfc/rfc2119.txt
