### PR TITLE
Allow Named & Typed objects to be compared with ==

### DIFF
--- a/src/terraformpy/objects.py
+++ b/src/terraformpy/objects.py
@@ -120,6 +120,9 @@ class NamedObject(TFObject):
         raise RuntimeError("%ss does not provide attribute interpolation through attribute access!" %
                            self.__class__.__name__)
 
+    def __eq__(self, other):
+        return self._name == other._name and self._values == other._values
+
     def build(self):
         result = {
             self.TF_TYPE: {
@@ -149,6 +152,9 @@ class TypedObject(NamedObject):
     def __init__(self, _type, _name, **kwargs):
         super(TypedObject, self).__init__(_name, **kwargs)
         self._type = _type
+
+    def __eq__(self, other):
+        return self._type == other._type and super(TypedObject, self).__eq__(other)
 
     @property
     def terraform_name(self):

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -157,3 +157,19 @@ def test_interpolated():
 
     # call .name again to ensure ._frozen is reset correctly and we can still mutate the original
     assert foo.name == 'sg'
+
+
+def test_equality():
+    # NamedObject
+    p1 = Provider("mysql", host="db")
+    p2 = Provider("mysql", host="db")
+    v1 = Variable("mysql", host="db")
+    assert p1 == p2
+    assert p1 != v1
+
+    # TypedObject
+    r1 = Resource('aws_security_group', 'sg', name='sg')
+    r2 = Resource('aws_security_group', 'sg', name='sg')
+    d1 = Data('aws_security_group', 'sg', name='sg')
+    assert r1 == r2
+    assert r1 != d1


### PR DESCRIPTION
This PR provides `__eq__` (equality operators) for `NamedObject` and `TypedObject` so that two differently instantiated objects with the same properties will compare correctly.