### PR TITLE
Make finalize_resources explicit about how it operates

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -186,6 +186,14 @@ your clusters.  You can express that with a resource collection:
             )
 
 
+        # sometimes you need to create resources late, right before the Python objects are converted to JSON
+        # the finalize_resources method is called on all ResourceCollection instances, in the opposite order they were
+        # created in, right before compiling
+
+        def finalize_resources(self):
+            pass
+
+
 That definition can then be imported and used in your terraformpy configs.
 
 .. code-block:: python

--- a/src/terraformpy/objects.py
+++ b/src/terraformpy/objects.py
@@ -66,7 +66,7 @@ class TFObject(object):
 
         # allow resource collections to have a final hurrah before we compile
         if ResourceCollection._instances:
-            for collection in ResourceCollection._instances:
+            for collection in reversed(ResourceCollection._instances):
                 collection.finalize_resources()
 
         def recursive_compile(cls):

--- a/tests/test_resource_collections.py
+++ b/tests/test_resource_collections.py
@@ -2,7 +2,7 @@ import pytest
 import schematics.types
 import schematics.exceptions
 
-from terraformpy.objects import Resource
+from terraformpy.objects import Resource, TFObject
 from terraformpy.resource_collections import ResourceCollection, Input, MissingInput, Variant
 
 
@@ -128,3 +128,34 @@ def test_relative_file():
     tc = TestCollection(foo='foo!')
 
     assert tc.relative_file('foo') == '${file("${path.module}/tests/foo")}'
+
+
+def test_finalize_ordering():
+    """Finalize should run in the reverse order that resource collections are created"""
+    class TC1(ResourceCollection):
+        def create_resources(self):
+            self.finalized = False
+            self.tc2 = None
+
+        def finalize_resources(self):
+            self.finalized = True
+            assert self.tc2 is not None
+
+    class TC2(ResourceCollection):
+        tc1 = Input()
+
+        def create_resources(self):
+            pass
+
+        def finalize_resources(self):
+            self.tc1.tc2 = self
+
+    tc1 = TC1()
+    tc2 = TC2(tc1=tc1)
+
+    assert not tc1.finalized
+
+    TFObject.compile()
+
+    assert tc1.finalized
+    assert tc1.tc2 == tc2


### PR DESCRIPTION
This PR ensures `finalize_resources` runs in an explicitly determined order.

The motivation for this is loosely coupled resource collections that register themselves with each other.