### PR TITLE
Remove warning for input being in a variant and default kwargs

### DIFF
--- a/src/terraformpy/resource_collections.py
+++ b/src/terraformpy/resource_collections.py
@@ -1,5 +1,3 @@
-import warnings
-
 import schematics.types
 
 from terraformpy.helpers import relative_file as _relative_file


### PR DESCRIPTION
Originally it was assumed that an input should be specified for all variants of a Resource Collection.
However, use cases have arisen where it is desirable to only override the default value for one variant and have all other variants use the default value.

This PR removes the warning, now that we are adopting this as expected use case.