### PR TITLE
Allow relative calculation to be used without ${file}

### DIFF
--- a/src/terraformpy/helpers.py
+++ b/src/terraformpy/helpers.py
@@ -26,7 +26,11 @@ def relative_file(filename, _caller_depth=1):
         "template": "${file(\"${path.module}/../../../modules/mything/files/foo.json\")}",
 
     """
+    return '${{file("{0}")}}'.format(relative_path(filename, _caller_depth=_caller_depth+1))
+
+
+def relative_path(path, _caller_depth=1):
     caller = inspect.stack()[_caller_depth]
-    return '${{file("${{path.module}}/{0}")}}'.format(
-        os.path.relpath(os.path.join(os.path.dirname(caller[1]), filename))
+    return '${{path.module}}/{0}'.format(
+        os.path.relpath(os.path.join(os.path.dirname(caller[1]), path))
     )


### PR DESCRIPTION
Currently the `relative_file` helper always returns a `${file(...)}` interpolation, but in some cases we want the path (`...`) without the interpolation function -- like when we're feeding a directory into the archive data type.

This PR refactors the helpers function to have a `relative_path` function that contains the actual path calculation logic, and `relative_file` just uses it now.