### PR TITLE
[OPS-3014] - Recursion TypedObjectAttr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.0.7
+
+Update TypedObjecAttr to build itself recursively.
+
 # 1.0.6
 
 Update TypedObjecAttr to format for integer-based arrays.

--- a/src/terraformpy/objects.py
+++ b/src/terraformpy/objects.py
@@ -218,18 +218,11 @@ class TypedObjectAttr(str):
         else:
             return '{0}["{1}"]'.format(name, item)
 
-    @staticmethod
-    def _name_with_attribute(name, item):
-        if item is None:
-            return name
-        else:
-            return '{0}.{1}'.format(name, item)
-
     def __getitem__(self, item):
         return TypedObjectAttr(self._terraform_name, self._name_with_index(self._name, self._item), item)
 
-    # def __getattr__(self, item):
-    #     return TypedObjectAttr(self._terraform_name, self._name_with_attribute(self._name, self._item), item)
+    def __getattr__(self, item):
+        return TypedObjectAttr(self._terraform_name, self._name_with_index(self._name, self._item), item)
 
 
 class TypedObject(NamedObject):

--- a/tests/test_resource_collections.py
+++ b/tests/test_resource_collections.py
@@ -194,19 +194,19 @@ def test_typed_item_recursion():
     assert tc.bar == '${data.data_type.data_id.baz[1]["resource_collection"]["resource"]}'
 
 
-# def test_typed_attr_recursion():
-#     class TestCollection(ResourceCollection):
-#         foo = types.StringType(required=True)
-#         bar = types.StringType(required=True)
+def test_typed_attr_recursion():
+    class TestCollection(ResourceCollection):
+        foo = types.StringType(required=True)
+        bar = types.StringType(required=True)
 
-#         def create_resources(self):
-#             pass
+        def create_resources(self):
+            pass
 
-#     data = Data('data_type', 'data_id')
+    data = Data('data_type', 'data_id')
 
-#     tc = TestCollection(foo=data.baz[0].resource_collection.resource, bar=data.baz[1].resource_collection.resource)
-#     assert tc.foo == '${data.data_type.data_id.baz[0].resource_collection.resource}'
-#     assert tc.bar == '${data.data_type.data_id.baz[1].resource_collection.resource}'
+    tc = TestCollection(foo=data.baz[0].resource_collection.resource, bar=data.baz[1].resource_collection.resource)
+    assert tc.foo == '${data.data_type.data_id.baz[0]["resource_collection"]["resource"]}'
+    assert tc.bar == '${data.data_type.data_id.baz[1]["resource_collection"]["resource"]}'
 
 
 def test_model_type():


### PR DESCRIPTION
https://nerdwallet.atlassian.net/browse/OPS-3014

Sometimes, Terraform attributes have lists and objects in mixed formats at varying levels - and we don't know about them. So I would like to be able to request values like:

```
self.nwcert.data_validation_model[0].resource_name == {$aws_acm_certificate.cert.data_validation_model[0].resource_name}
```

We may similarly want to interpret things like `resources.resource_name` or `[0]["resource_name"]` or `resources.[0].resource_name`. So flexibility would help insulate us down the road.

Concrete usage example: https://github.com/NerdWallet/terraform-aws/pull/1571/files#diff-dcb43fbb87848c9a749df32ed710bd29R32