### PR TITLE
comaptibily with newer python collections.abc issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+# Use a free architecture - see https://docs.travis-ci.com/user/billing-overview/#partner-queue-solution
+arch: arm64
+
 language: python
 sudo: false
 

--- a/src/terraformpy/objects.py
+++ b/src/terraformpy/objects.py
@@ -29,12 +29,12 @@ from .resource_collections import Variant
 def recursive_update(dest, source):
     """Like dict.update, but recursive"""
     try:
-        mapping = collections.abc.Mapping
+        from collections.abc import Mapping
     except ImportError:
-        mapping = collections.Mapping
+        from collections import Mapping
 
     for key, val in six.iteritems(source):
-        if isinstance(val, mapping):
+        if isinstance(val, Mapping):
             recurse = recursive_update(dest.get(key, {}), val)
             dest[key] = recurse
         else:

--- a/src/terraformpy/objects.py
+++ b/src/terraformpy/objects.py
@@ -29,7 +29,7 @@ from .resource_collections import Variant
 def recursive_update(dest, source):
     """Like dict.update, but recursive"""
     for key, val in six.iteritems(source):
-        if isinstance(val, collections.Mapping):
+        if isinstance(val, collections.abc.Mapping):
             recurse = recursive_update(dest.get(key, {}), val)
             dest[key] = recurse
         else:

--- a/src/terraformpy/objects.py
+++ b/src/terraformpy/objects.py
@@ -28,8 +28,13 @@ from .resource_collections import Variant
 
 def recursive_update(dest, source):
     """Like dict.update, but recursive"""
+    try:
+        mapping = collections.abc.Mapping
+    except ImportError:
+        mapping = collections.Mapping
+
     for key, val in six.iteritems(source):
-        if isinstance(val, collections.abc.Mapping):
+        if isinstance(val, mapping):
             recurse = recursive_update(dest.get(key, {}), val)
             dest[key] = recurse
         else:


### PR DESCRIPTION
I'm using terraformpy and this is really great tool

Currently I use python 3.7, but wanted to switch to python 3.10

however, terraformpy is not compatible yet

This fix makes terraformpy compatible with python > 3.8 and preserves backward compatibility with older python versions.